### PR TITLE
bump: nextjs-toploader version from 1.6.4 to 1.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "next": "14.1.0",
     "next-auth": "^4.24.5",
     "next-themes": "^0.2.1",
-    "nextjs-toploader": "^1.6.4",
+    "nextjs-toploader": "^1.6.6",
     "postcss": "8.4.33",
     "prisma": "^5.8.1",
     "react": "18.2.0",


### PR DESCRIPTION
Fixes #32 