### PR TITLE
Included images in MarkDownView parsing to allow pop up modal for lar…

### DIFF
--- a/src/components/modals/ImageModal.tsx
+++ b/src/components/modals/ImageModal.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+
+type ImageProps = {
+  src: string;
+  alt: string;
+  width?: string | number;
+  height?: string | number;
+};
+
+const ImageWithModal: React.FC<ImageProps> = ({ src, alt }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  return (
+    <>
+      <div className="relative w-full h-64 cursor-pointer" onClick={() => setIsModalOpen(true)}>
+        <Image
+          src={src}
+          alt={alt}
+          fill
+          style={{ objectFit: "contain" }}
+        />
+      </div>
+      {isModalOpen && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-90 flex justify-center items-center z-50"
+          onClick={() => setIsModalOpen(false)}
+        >
+          <div className="relative w-screen h-screen p-4">
+            <Image
+              src={src}
+              alt={alt}
+              fill
+              style={{ objectFit: "contain" }}
+            />
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsModalOpen(false);
+              }}
+              className="absolute top-4 right-4 bg-white dark:bg-gray-800 rounded-full p-2 z-10"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ImageWithModal;

--- a/src/components/modals/ImageModal.tsx
+++ b/src/components/modals/ImageModal.tsx
@@ -27,11 +27,11 @@ const ImageWithModal: React.FC<ImageProps> = ({ src, alt }) => {
           className="fixed inset-0 bg-black bg-opacity-90 flex justify-center items-center z-50"
           onClick={() => setIsModalOpen(false)}
         >
-          <div className="relative w-screen h-screen p-4">
+          <div className="relative w-screen h-screen p-4 flex justify-center items-center">
             <img
               src={src}
               alt={alt}
-              style={{ objectFit: "contain" }}
+              className="w-full h-full object-contain"
             />
             <button
               onClick={(e) => {

--- a/src/components/modals/ImageModal.tsx
+++ b/src/components/modals/ImageModal.tsx
@@ -16,10 +16,9 @@ const ImageWithModal: React.FC<ImageProps> = ({ src, alt }) => {
   return (
     <>
       <div className="relative w-full h-64 cursor-pointer" onClick={() => setIsModalOpen(true)}>
-        <Image
+        <img
           src={src}
           alt={alt}
-          fill
           style={{ objectFit: "contain" }}
         />
       </div>
@@ -29,10 +28,9 @@ const ImageWithModal: React.FC<ImageProps> = ({ src, alt }) => {
           onClick={() => setIsModalOpen(false)}
         >
           <div className="relative w-screen h-screen p-4">
-            <Image
+            <img
               src={src}
               alt={alt}
-              fill
               style={{ objectFit: "contain" }}
             />
             <button

--- a/src/components/views/MarkDownView.tsx
+++ b/src/components/views/MarkDownView.tsx
@@ -1,9 +1,10 @@
+import { FC, ReactNode } from "react";
 import clsx from "clsx";
-import { FC, ReactNode, memo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import BoardMembers from "../about/BoardMembers";
+import ImageWithModal from "@/components/modals/ImageModal";
 
 type Props = {
   className?: string;
@@ -12,7 +13,8 @@ type Props = {
   allowLinks?: boolean;
 };
 
-const MarkDownView: FC<Props> = memo(function MarkdownView({ className, markdown, allowLinks }) {
+// memo removed to prevent hydration mismatch
+const MarkDownView: FC<Props> = function MarkdownView({ className, markdown, allowLinks }) {
   return (
     <ReactMarkdown
       className={clsx(className, "prose w-full max-w-none break-words dark:prose-invert")}
@@ -24,12 +26,13 @@ const MarkDownView: FC<Props> = memo(function MarkdownView({ className, markdown
           if (allowLinks) return <a {...props} />;
           return <span className="font-medium underline" {...props} />;
         },
+        img: ({ node, ...props }) => <ImageWithModal src={props.src || ''} alt={props.alt ?? ''} {...props} />,
         // @ts-ignore
         members: BoardMembers,
       }}>
       {markdown}
     </ReactMarkdown>
   );
-});
+};
 
 export default MarkDownView;


### PR DESCRIPTION
…ger image.

Before Image Click:
![image](https://github.com/user-attachments/assets/77c7abb4-a443-4e13-8279-86d4be00696f)
After:
![image](https://github.com/user-attachments/assets/dd1e96ee-7d45-4042-ac6e-0ea8c737bb57)


### What are you trying to accomplish?

Make images able to open a modal on click to allow users to see smaller images more clearly. 

### How are you accomplishing it?
It wasn't as easy for MarkdownView because the img elements needs to be parsed and MarkdownView is in server side which required me to not have useStates in that file. Otherwise, HTML's new dialog element would've made it much easier. 

Keep server side MarkdownView the same, have it parse img: --> to client side component ImageModal to handle the modal logic. Unfortunately memo() had problems with hydration that I couldn't figure out a fix nor understand why.

### Is there anything reviewers should know?


- [x] Is it safe to rollback this change if anything goes wrong?
