### PR TITLE
add gallery to highlights

### DIFF
--- a/prisma/developmentData/highlights.json
+++ b/prisma/developmentData/highlights.json
@@ -16,7 +16,7 @@
     "content": "This is a test post"
   },
   {
-    "title": "Test Post with Banner",
-    "content": "This is a test post with a banner."
+    "title": "Test Post without Banner",
+    "content": "This is a test post without a banner."
   }
 ]

--- a/prisma/developmentData/highlights.json
+++ b/prisma/developmentData/highlights.json
@@ -17,8 +17,6 @@
   },
   {
     "title": "Test Post with Banner",
-    "content": "This is a test post with a banner.",
-    "bannerUrl": "https://github.com/UWindsorCSS/logos-and-branding/raw/master/CSS%20Full%20Logo/CSS%20Logo%20White%20Text.png?raw=true",
-    "bannerAlt": "CSS Logo"
+    "content": "This is a test post with a banner."
   }
 ]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -143,13 +143,11 @@ model ThumbnailImage {
   eventId   Int?     @unique
 }
 
-// Newsletter Post
+// highlights Post
 model Post {
   id        Int      @id @default(autoincrement())
   title     String
   content   String   @db.Text
-  bannerUrl  String?
-  bannerAlt  String?
   author    User?    @relation(fields: [authorId], references: [id])
   authorId  Int?
   createdAt DateTime @default(now())

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -58,8 +58,6 @@ async function seed() {
         data: {
           title: highlightData.title,
           id: highlightData.id,
-          bannerUrl: highlightData.bannerUrl,
-          bannerAlt: highlightData.bannerAlt,
           content: highlightData.content,
         },
       });

--- a/src/app/(pages)/highlight/[id]/page.tsx
+++ b/src/app/(pages)/highlight/[id]/page.tsx
@@ -9,6 +9,8 @@ import { deletePost } from "@/lib/actions";
 import DeleteButton from "@/components/DeleteButton";
 import { AlarmClock, User } from "lucide-react";
 import { auth } from "@/auth";
+import NextLink from "next/link";
+import { Button } from "@/components/ui/button";
 
 interface PageProps {
   params: { id: string };
@@ -47,10 +49,6 @@ export default async function Post({ params, searchParams }: PageProps) {
   return (
     <FeedView
       heading={post?.title}
-      banner={(post?.bannerUrl && {
-        url: post?.bannerUrl ?? "",
-        alt: post?.bannerAlt ?? "Banner image for the highlight."
-      }) || undefined}
       subheadings={[
         {
           text: authorName,
@@ -59,14 +57,20 @@ export default async function Post({ params, searchParams }: PageProps) {
           Icon2: AlarmClock,
         },
       ]}>
-
-      {session && canEditPost(session) && (
-        <div className="my-2 flex w-full flex-wrap gap-2">
+      <div className="my-2 flex w-full flex-wrap gap-2">
+        <NextLink href={`/gallery/${post.id}`}>
+          <Button>
+            View Gallery
+          </Button>
+        </NextLink>
+        {session && canEditPost(session) && (
+          <>
           <EditPostButton id={post!.id} post={post!} />
           <DeleteButton type={"post"} callback={deletePost} id={post!.id} />
-        </div>
+          </>
       )}
-      <MarkDownView allowLinks markdown={post!.content} />
+    </div>
+  <MarkDownView allowLinks markdown={post!.content} />
       <div className="mt-10 w-full">
         <BackButton href="/highlight" searchParams={searchParams} />
       </div>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -36,12 +36,6 @@ function PostCard({ post, currentPage, filter, truncate = false }: ContentProps)
   const linkUrl = isEvent
     ? `/events/${post.id}?page=${currentPage}${filter ? `&filter=${filter}` : ""}`
     : `/highlight/${post.id}${currentPage ? `?page=${currentPage}` : ""}`;
-  const banner = !isEvent && post.bannerUrl
-    ? {
-        url: post.bannerUrl ?? "",
-        alt: post.bannerAlt ?? "Banner image for the highlight.",
-      }
-    : false;
   const content = isEvent ? post.description : post.content;
   const numOfLines: number = markdownToTextWithNewLines(content!).split("\n").length;
   const truncateContent = truncate && (content!.length > 400 || numOfLines > 5);
@@ -65,11 +59,6 @@ function PostCard({ post, currentPage, filter, truncate = false }: ContentProps)
       )}
 
       <h2 className="text-xl font-semibold sm:text-2xl">{title}</h2>
-      {banner && (
-        <img className="w-full max-h-[60vh] object-contain rounded-md" src={banner.url} alt={banner.alt} />
-        // TODO: ^ should prob use nextjs Image, but causes problems when using external URLS
-        // TODO: (fix) with non-landscape images, the corners wont be rounded
-      )}
       <div className="flex flex-col flex-wrap gap-2 text-sm font-medium text-muted-foreground md:flex-row">
         <PostInfo post={post} />
       </div>

--- a/src/components/newsletter/PostFormDialog.tsx
+++ b/src/components/newsletter/PostFormDialog.tsx
@@ -19,10 +19,6 @@ const postSchema = z.object({
       required_error: "The content is required.",
     })
     .min(1),
-  bannerUrl: z.string().optional(),
-  bannerAlt: z.string().optional(),
-  // TODO: ideally this should make it so alt text is required if an image is provided
-  //       using z.object() with .refine() could be a potential solution.
   isTeam: z.boolean().optional(),
 });
 
@@ -40,8 +36,6 @@ function PostFormDialog({ triggerButton, id, initialValues }: PostFormProps) {
     defaultValues: initialValues || {
       title: "",
       content: "",
-      bannerUrl: "",
-      bannerAlt: "",
       isTeam: false,
     },
   });
@@ -51,8 +45,6 @@ function PostFormDialog({ triggerButton, id, initialValues }: PostFormProps) {
       title: data.title,
       isTeam: data.isTeam,
       content: data.content,
-      bannerUrl: data.bannerUrl,
-      bannerAlt: data.bannerAlt,
     };
 
     if (id) await updatePost(post, id);
@@ -73,8 +65,6 @@ function PostFormDialog({ triggerButton, id, initialValues }: PostFormProps) {
       pendingButtonText={id ? "Updating Post..." : "Creating Post..."}
       contentClassName="sm:max-w-[800px]">
       <Input label="Title" type="text" placeholder=" e.g. Newsletter" {...form.register("title")} />
-      <Input label="Banner URL" type="text" placeholder="Banner Image URL" {...form.register("bannerUrl")} />
-      <Input label="Banner Alt Text" type="text" placeholder="Banner Image Alt Text" {...form.register("bannerAlt")} />
       <Textarea
         label="Content"
         type="text"

--- a/src/components/newsletter/newsletter-post/EditPostButton.tsx
+++ b/src/components/newsletter/newsletter-post/EditPostButton.tsx
@@ -7,8 +7,6 @@ function EditPostButton({ id, post }: { id: number; post: Post }) {
   const values = {
     title: post.title || "",
     content: post.content || "",
-    bannerUrl: post.bannerUrl || "",
-    bannerAlt: post.bannerAlt || "",
     isTeam: post.authorId ? false : true,
   };
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -528,8 +528,6 @@ export async function createPost(post: PostFormData) {
     await prisma.post.create({
       data: {
         title: post.title,
-        bannerUrl: post.bannerUrl,
-        bannerAlt: post.bannerAlt,
         content: post.content,
         ...(post.isTeam ? {} : { author: { connect: { id: session.user.id } } }),
       },
@@ -550,8 +548,6 @@ export async function updatePost(post: PostFormData, id: number) {
 
     const data: any = {
       title: post.title,
-      bannerUrl: post.bannerUrl,
-      bannerAlt: post.bannerAlt,
       content: post.content,
     };
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -23,8 +23,6 @@ declare global {
   interface PostFormData {
     title: string;
     isTeam?: boolean;
-    bannerUrl?: string;
-    bannerAlt?: string;
     content: string;
   }
 


### PR DESCRIPTION
### What are you trying to accomplish?
Remove the banner URL system from the highlights tab and replace it with the Gallery system already in place with the events tab

### How are you accomplishing it?
Modified Highlights schema to remove banner URL and alt text, and cloned the gallery system from the events tab to the highlights tab

### Is there anything reviewers should know?

- [x] Is it safe to rollback this change if anything goes wrong?
